### PR TITLE
Fix: Add safe area wrapper to fix the issues with phone notches

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,7 +10,8 @@ import { useEffect } from "react";
 import "react-native-reanimated";
 import Toast from "react-native-toast-message";
 import { StateProvider } from "@/state/AppContext";
-
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { StyleSheet } from "react-native";
 import { useColorScheme } from "@/hooks/useColorScheme";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
@@ -34,13 +35,25 @@ export default function RootLayout() {
 
   return (
     <StateProvider>
-      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <Toast />
-      </ThemeProvider>
+      <SafeAreaProvider>
+        <ThemeProvider
+          value={colorScheme === "dark" ? DarkTheme : DefaultTheme}
+        >
+          <SafeAreaView style={styles.container}>
+            <Stack>
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <Toast />
+          </SafeAreaView>
+        </ThemeProvider>
+      </SafeAreaProvider>
     </StateProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
On devices with notches (e.g. iPhone 10+ ) parts of the app are hidden behind them and it provides a poor UX experience. By adding a Safe area wrapper we can avoid those issues.
If I had more time I would work on styling a bit more and improve the Tab bar visual appearance as well.